### PR TITLE
chore: update release workflow to use personal access token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # Full history needed for changelog generation
+          token: ${{ secrets.GH_PAT }} # PAT to bypass branch protection
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -41,13 +42,13 @@ jobs:
         if: ${{ inputs.dry-run }}
         run: yarn release --ci --dry-run --no-npm
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Release (version bump, changelog, git tag, GitHub release)
         if: ${{ !inputs.dry-run }}
         run: yarn release --ci --no-npm
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Publish to npm with provenance
         if: ${{ !inputs.dry-run }}


### PR DESCRIPTION
- Added GitHub Personal Access Token (GH_PAT) to bypass branch protection in the release workflow.
- Updated environment variable for GITHUB_TOKEN to use GH_PAT for both dry-run and actual release steps.