### PR TITLE
fix: ensure npm publish uses correct version with OIDC provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
+      - name: Pull latest changes after release
+        if: ${{ !inputs.dry-run }}
+        run: git pull --rebase
+
+      - name: Rebuild package with new version
+        if: ${{ !inputs.dry-run }}
+        run: yarn prepare
+
       - name: Publish to npm with provenance
         if: ${{ !inputs.dry-run }}
-        run: npm publish
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Fixes the release workflow for npm OIDC trusted publishing:

1. **Add `--provenance --access public` flags** to `npm publish` - required for OIDC trusted publishing to work
2. **Pull latest changes after release-it pushes** - ensures we have the bumped version in `package.json`
3. **Rebuild package before publishing** - ensures the tarball contains the correct version

## Problem

The previous workflow had two issues:
- Missing `--provenance` flag which is required for npm OIDC authentication
- `npm publish` was running with the old version because `release-it --no-npm` commits and pushes the version bump, but the local working directory still had the old `package.json`

## Testing

After merging, run the release workflow to verify npm publish succeeds with OIDC.