### PR TITLE
fix: use npm version and conventional-changelog for version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Release (dry run)
         if: ${{ inputs.dry-run }}
-        run: yarn release --ci --dry-run --no-npm
+        run: yarn release --ci --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
@@ -56,21 +56,35 @@ jobs:
       # then create the GitHub release only after npm succeeds.
       # This prevents orphaned GitHub releases if npm publish fails.
 
-      - name: Bump version and update changelog (no git push yet)
+      - name: Determine version bump type
+        if: ${{ !inputs.dry-run }}
+        id: bump-type
+        run: |
+          # Use conventional-recommended-bump to determine bump type based on commits
+          BUMP_TYPE=$(npx conventional-recommended-bump -p angular)
+          echo "type=${BUMP_TYPE}" >> $GITHUB_OUTPUT
+          echo "Recommended bump type: ${BUMP_TYPE}"
+
+      - name: Bump version
         if: ${{ !inputs.dry-run }}
         id: version-bump
         run: |
-          # Run release-it with no git push, no GitHub release, no npm
-          # This only bumps version and updates changelog locally
-          yarn release --ci --no-npm --no-git.push --no-git.tag --no-github
+          BUMP_TYPE="${{ steps.bump-type.outputs.type }}"
+
+          # Bump version without creating git tag (we'll do that after npm publish)
+          npm version "${BUMP_TYPE}" --no-git-tag-version
 
           # Get the new version
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "tag=v${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "New version: ${NEW_VERSION}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+
+      - name: Update changelog
+        if: ${{ !inputs.dry-run }}
+        run: |
+          VERSION="${{ steps.version-bump.outputs.version }}"
+          npx conventional-changelog -p angular -i CHANGELOG.md -s -r 1
 
       - name: Rebuild package with new version
         if: ${{ !inputs.dry-run }}
@@ -102,7 +116,6 @@ jobs:
           TAG="${{ steps.version-bump.outputs.tag }}"
 
           # Extract changelog for this version
-          # Look for content between this version header and the next version header
           CHANGELOG=$(awk "/^## \\[${VERSION}\\]|^## ${VERSION}/,/^## \\[|^## [0-9]/" CHANGELOG.md | head -n -1)
 
           gh release create "${TAG}" \


### PR DESCRIPTION
## Summary

Fixes the version bump step that wasn't working.

## Problem

`release-it` with `--no-git.push --no-git.tag --no-github` flags wasn't actually bumping the version - it was still publishing 0.3.0.

## Solution

Replace the partial release-it approach with direct tooling:

1. **`npx conventional-recommended-bump -p angular`** - Determines bump type (patch/minor/major) based on conventional commits
2. **`npm version <type> --no-git-tag-version`** - Bumps the version in package.json without creating a git tag
3. **`npx conventional-changelog -p angular -i CHANGELOG.md -s -r 1`** - Updates the changelog

This gives us full control over each step and ensures the version is actually bumped before npm publish.

## Flow

1. Determine bump type from commits
2. Bump version in package.json
3. Update CHANGELOG.md
4. Rebuild with new version
5. Publish to npm
6. Only then: commit, tag, push, create GitHub release