### PR TITLE
feat: switch to static MisakiSwift fork for simpler installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-misaki
 
-React Native bindings for [MisakiSwift](https://github.com/mlalma/MisakiSwift), a Swift G2P (grapheme-to-phoneme) library for converting English text to IPA phonemes. Perfect for text-to-speech applications like [Kokoro TTS](https://github.com/hexgrad/kokoro).
+React Native bindings for [MisakiSwift](https://github.com/mlalma/MisakiSwift), a Swift G2P (grapheme-to-phoneme) library for converting English text to IPA phonemes. Designed for text-to-speech applications such as [Kokoro TTS](https://github.com/hexgrad/kokoro).
 
 ## Requirements
 
@@ -10,9 +10,9 @@ React Native bindings for [MisakiSwift](https://github.com/mlalma/MisakiSwift), 
 | **iOS Version**  | 18.0+                               |
 | **React Native** | 0.75+                               |
 
-> **Note**: This library uses a [static fork of MisakiSwift](https://github.com/tolulawson/MisakiSwift) which eliminates the need for `use_frameworks! :linkage => :dynamic` in your Podfile.
+> **Note:** This library uses a [static fork of MisakiSwift](https://github.com/tolulawson/MisakiSwift) which eliminates the need for `use_frameworks! :linkage => :dynamic` in your Podfile.
 
-> **Simulator not supported**: This library uses MLX under the hood, which does not run on iOS Simulator. You must test on a physical device.
+> **Simulator Limitation:** This library uses MLX under the hood, which does not run on iOS Simulator. Testing requires a physical device.
 
 ## Installation
 
@@ -20,7 +20,7 @@ React Native bindings for [MisakiSwift](https://github.com/mlalma/MisakiSwift), 
 npm install react-native-misaki react-native-nitro-modules
 ```
 
-> `react-native-nitro-modules` is required as this library uses [Nitro Modules](https://nitro.margelo.com/) for zero-overhead native bindings.
+`react-native-nitro-modules` is required as this library uses [Nitro Modules](https://nitro.margelo.com/) for native bindings.
 
 ### iOS Setup
 
@@ -38,11 +38,11 @@ platform :ios, '18.0'
 cd ios && pod install
 ```
 
-That's it! No special framework configuration is required.
+No additional framework configuration is required.
 
 ### Expo Setup
 
-This library requires a [development build](https://docs.expo.dev/develop/development-builds/introduction/) — it does not work with Expo Go.
+This library requires a [development build](https://docs.expo.dev/develop/development-builds/introduction/) and is not compatible with Expo Go.
 
 **1. Install dependencies**
 
@@ -81,7 +81,7 @@ npx expo prebuild --platform ios --clean
 npx expo run:ios --device
 ```
 
-> You must use `--device` to run on a physical device. The iOS Simulator is not supported due to MLX limitations.
+The `--device` flag is required as the iOS Simulator is not supported due to MLX limitations.
 
 ## Usage
 
@@ -164,7 +164,7 @@ Each token represents a word or punctuation from the input text:
 
 ### App crashes on simulator
 
-This library does not support the iOS Simulator. MLX, which powers MisakiSwift, requires Apple Silicon and does not run in the simulated environment. You must use a physical iOS device.
+This library does not support the iOS Simulator. MLX, which powers MisakiSwift, requires Apple Silicon and does not run in the simulated environment. A physical iOS device is required for testing.
 
 ### Build fails with deployment target error
 
@@ -205,7 +205,7 @@ Then regenerate the native project:
 npx expo prebuild --platform ios --clean
 ```
 
-### "Expo Go" is not supported
+### Expo Go is not supported
 
 This library includes native code and requires a development build. Expo Go cannot load native modules. Use:
 
@@ -225,7 +225,7 @@ npx react-native run-ios -- CODE_SIGNING_ALLOWED=NO
 npx expo run:ios --device -- CODE_SIGNING_ALLOWED=NO
 ```
 
-See [IMPLEMENTATION.md](./IMPLEMENTATION.md) for more details.
+See [IMPLEMENTATION.md](./IMPLEMENTATION.md) for additional details.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ React Native bindings for [MisakiSwift](https://github.com/mlalma/MisakiSwift), 
 | **Platform**     | iOS only (physical device required) |
 | **iOS Version**  | 18.0+                               |
 | **React Native** | 0.75+                               |
-| **Frameworks**   | Dynamic frameworks enabled          |
 
-> ⚠️ **Simulator not supported**: This library uses MLX under the hood, which does not run on iOS Simulator. You must test on a physical device.
+> **Note**: This library uses a [static fork of MisakiSwift](https://github.com/tolulawson/MisakiSwift) which eliminates the need for `use_frameworks! :linkage => :dynamic` in your Podfile.
+
+> **Simulator not supported**: This library uses MLX under the hood, which does not run on iOS Simulator. You must test on a physical device.
 
 ## Installation
 
@@ -31,19 +32,13 @@ In your `ios/Podfile`, add or update:
 platform :ios, '18.0'
 ```
 
-**2. Enable dynamic frameworks**
-
-Required for Swift Package Manager dependencies:
-
-```ruby
-use_frameworks! :linkage => :dynamic
-```
-
-**3. Install pods**
+**2. Install pods**
 
 ```sh
 cd ios && pod install
 ```
+
+That's it! No special framework configuration is required.
 
 ### Expo Setup
 
@@ -57,7 +52,7 @@ npx expo install react-native-misaki react-native-nitro-modules expo-build-prope
 
 **2. Configure `app.json`**
 
-Add the config plugin to set iOS 18.0 deployment target and enable dynamic frameworks:
+Add the config plugin to set iOS 18.0 deployment target:
 
 ```json
 {
@@ -67,8 +62,7 @@ Add the config plugin to set iOS 18.0 deployment target and enable dynamic frame
         "expo-build-properties",
         {
           "ios": {
-            "deploymentTarget": "18.0",
-            "useFrameworks": "dynamic"
+            "deploymentTarget": "18.0"
           }
         }
       ]
@@ -87,7 +81,7 @@ npx expo prebuild --platform ios --clean
 npx expo run:ios --device
 ```
 
-> ⚠️ You must use `--device` to run on a physical device. The iOS Simulator is not supported due to MLX limitations.
+> You must use `--device` to run on a physical device. The iOS Simulator is not supported due to MLX limitations.
 
 ## Usage
 
@@ -196,8 +190,7 @@ Ensure `expo-build-properties` is configured in your `app.json`:
         "expo-build-properties",
         {
           "ios": {
-            "deploymentTarget": "18.0",
-            "useFrameworks": "dynamic"
+            "deploymentTarget": "18.0"
           }
         }
       ]

--- a/RNMisaki.podspec
+++ b/RNMisaki.podspec
@@ -19,15 +19,19 @@ Pod::Spec.new do |s|
     "cpp/**/*.{hpp,cpp}",
   ]
 
-  s.dependency 'React-jsi'
-  s.dependency 'React-callinvoker'
-
-  # Add MisakiSwift SPM dependency
+  # Use the forked MisakiSwift with static library support
+  # This eliminates the need for use_frameworks! :linkage => :dynamic
   spm_dependency(s,
-    url: 'https://github.com/mlalma/MisakiSwift.git',
-    requirement: {kind: 'upToNextMajorVersion', minimumVersion: '1.0.1'},
+    url: 'https://github.com/tolulawson/MisakiSwift.git',
+    requirement: {kind: 'branch', branch: 'static-library'},
     products: ['MisakiSwift']
   )
+
+  # Required system frameworks for MLX
+  s.frameworks = ['Metal', 'Accelerate', 'Foundation', 'NaturalLanguage']
+
+  s.dependency 'React-jsi'
+  s.dependency 'React-callinvoker'
 
   load 'nitrogen/generated/ios/RNMisaki+autolinking.rb'
   add_nitrogen_files(s)

--- a/example/ios/MisakiExample.xcodeproj/project.pbxproj
+++ b/example/ios/MisakiExample.xcodeproj/project.pbxproj
@@ -8,9 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		1E41FC15E269099CE80D2F00 /* libPods-MisakiExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D5F3A8CD548AB600964A3F31 /* libPods-MisakiExample.a */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		82164052B800A4C37E8AAB32 /* Pods_MisakiExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AB5CFB1FAB8E2EACB1FB8D4 /* Pods_MisakiExample.framework */; };
 		C2F27E225391B70C97F97756 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
@@ -20,10 +20,10 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = MisakiExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = MisakiExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-MisakiExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MisakiExample.debug.xcconfig"; path = "Target Support Files/Pods-MisakiExample/Pods-MisakiExample.debug.xcconfig"; sourceTree = "<group>"; };
-		4AB5CFB1FAB8E2EACB1FB8D4 /* Pods_MisakiExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MisakiExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5709B34CF0A7D63546082F79 /* Pods-MisakiExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MisakiExample.release.xcconfig"; path = "Target Support Files/Pods-MisakiExample/Pods-MisakiExample.release.xcconfig"; sourceTree = "<group>"; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = MisakiExample/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = MisakiExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D5F3A8CD548AB600964A3F31 /* libPods-MisakiExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MisakiExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -32,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82164052B800A4C37E8AAB32 /* Pods_MisakiExample.framework in Frameworks */,
+				1E41FC15E269099CE80D2F00 /* libPods-MisakiExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				4AB5CFB1FAB8E2EACB1FB8D4 /* Pods_MisakiExample.framework */,
+				D5F3A8CD548AB600964A3F31 /* libPods-MisakiExample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/example/ios/MisakiExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example/ios/MisakiExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "39442cd9809c645416f7e5a7df8878ddc2ddf6e87d7bbe52f3a3da774325d179",
+  "originHash" : "895a8ac70641667275e6068db6b3acf73b0a9bffc69d4c2d93f1689bb8daaa4b",
   "pins" : [
     {
       "identity" : "misakiswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mlalma/MisakiSwift.git",
+      "location" : "https://github.com/tolulawson/MisakiSwift.git",
       "state" : {
-        "revision" : "bb5e3e3671ef550dc545a98f4a4c15f58ee649ec",
-        "version" : "1.0.5"
+        "branch" : "static-library",
+        "revision" : "c482ff2a3a47b8d49e891b14dc9c1bdaea7bc3a6"
       }
     },
     {

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -10,8 +10,7 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, '18.0'
 prepare_react_native_project!
 
-# Required for SPM dependencies like MisakiSwift
-use_frameworks! :linkage => :dynamic
+# No use_frameworks! required - MisakiSwift is built as a static library
 
 target 'MisakiExample' do
   config = use_native_modules!
@@ -29,85 +28,17 @@ target 'MisakiExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
-    
+
     # Fix deployment target for all pods
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
       end
     end
-    
+
     # Also fix the Pods project itself
     installer.pods_project.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
-    end
-    
-    # Fix deployment target and add SPM framework embedding for main project
-    main_project_path = installer.sandbox.root.parent + 'MisakiExample.xcodeproj'
-    if File.exist?(main_project_path.to_s)
-      main_project = Xcodeproj::Project.open(main_project_path)
-      
-      main_project.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
-      end
-      
-      main_project.targets.each do |target|
-        target.build_configurations.each do |config|
-          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
-        end
-        
-        # Add script phase to embed SPM frameworks for the main app target
-        if target.name == 'MisakiExample'
-          phase_name = '[SPM] Embed MisakiSwift Frameworks'
-          
-          # Check if phase already exists
-          existing_phase = target.shell_script_build_phases.find { |p| p.name == phase_name }
-          
-          unless existing_phase
-            phase = target.new_shell_script_build_phase(phase_name)
-            phase.shell_script = <<-SCRIPT
-# Embed SPM dynamic frameworks that aren't automatically embedded
-FRAMEWORKS_DIR="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-mkdir -p "${FRAMEWORKS_DIR}"
-
-# List of SPM frameworks to embed
-SPM_FRAMEWORKS=(
-  "MisakiSwift"
-  "MLX"
-  "MLXNN"
-  "MLXRandom"
-  "Cmlx"
-  "MLXUtilsLibrary"
-)
-
-for fw in "${SPM_FRAMEWORKS[@]}"; do
-  FRAMEWORK_PATH="${BUILD_DIR}/Debug-${PLATFORM_NAME}/PackageFrameworks/${fw}.framework"
-  if [ -d "${FRAMEWORK_PATH}" ]; then
-    echo "Embedding ${fw}.framework"
-    cp -R "${FRAMEWORK_PATH}" "${FRAMEWORKS_DIR}/"
-    
-    # Sign the framework
-    if [ -n "${EXPANDED_CODE_SIGN_IDENTITY}" ]; then
-      codesign --force --sign "${EXPANDED_CODE_SIGN_IDENTITY}" --preserve-metadata=identifier,entitlements "${FRAMEWORKS_DIR}/${fw}.framework"
-    fi
-  else
-    echo "Warning: ${fw}.framework not found at ${FRAMEWORK_PATH}"
-  fi
-done
-SCRIPT
-            phase.input_paths = []
-            phase.output_paths = []
-            
-            # Move the phase to run after "Embed Pods Frameworks"
-            embed_pods_phase = target.shell_script_build_phases.find { |p| p.name&.include?('Embed Pods Frameworks') }
-            if embed_pods_phase
-              target.build_phases.move(phase, target.build_phases.index(embed_pods_phase) + 1)
-            end
-          end
-        end
-      end
-      
-      main_project.save
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR switches from the upstream MisakiSwift (dynamic library) to a forked version with static library support, eliminating the need for `use_frameworks! :linkage => :dynamic` in consuming apps.

## Changes

- **RNMisaki.podspec**: Use `tolulawson/MisakiSwift` fork with `static-library` branch
- **README.md**: Remove all references to `use_frameworks!` and dynamic frameworks
- **example/ios/Podfile**: Remove `use_frameworks! :linkage => :dynamic`
- **Xcode project**: Updated to link against static library instead of framework

## Before

```ruby
# Podfile
platform :ios, '18.0'
use_frameworks! :linkage => :dynamic

# Plus complex post_install script for SPM embedding
```

## After

```ruby
# Podfile
platform :ios, '18.0'

# That's it!
```

## Testing

- [x] Example app builds successfully
- [x] Example app runs on physical device
- [x] Phonemization works correctly

## Breaking Changes

None for end users - this is a simplification. Users who had `use_frameworks! :linkage => :dynamic` can now remove it (unless other dependencies require it).